### PR TITLE
Support for SLURM scheduler

### DIFF
--- a/bin/schedulers/__init__.py
+++ b/bin/schedulers/__init__.py
@@ -2,12 +2,14 @@ import os,sys
 from . import none
 from . import torque
 from . import fugaku
+from . import slurm
 
 
 SCHEDULER_TYPES = {
   "none": none.NoneScheduler,
   "torque": torque.TorqueScheduler,
-  "fugaku": fugaku.FugakuScheduler
+  "fugaku": fugaku.FugakuScheduler,
+  "slurm": slurm.SlurmScheduler
 }
 
 def create():

--- a/bin/schedulers/slurm.py
+++ b/bin/schedulers/slurm.py
@@ -1,0 +1,88 @@
+import pathlib,io,subprocess,datetime,re
+from typing import List,Tuple,Dict
+
+class SlurmScheduler:
+
+  PARAMETERS = {
+    "mpi_procs": { "description": "MPI process", "default": 1, "format": r'^[1-9]\d*$'},
+    "omp_threads": { "description": "OMP threads", "default": 1, "format": r'^[1-9]\d*$'},
+    "ppn": { "description": "Process per nodes", "default": 1, "format": r'^[1-9]\d*$'},
+    "walltime": { "description": "Limit on elapsed time", "default": "24:00:00", "format": r'^\d+:\d{2}:\d{2}$'}
+  }
+
+  @staticmethod
+  def validate_parameters(params: dict) -> None:
+    mpi = int(params["mpi_procs"])
+    omp = int(params["omp_threads"])
+    ppn = int(params["ppn"])
+    if mpi <= 0 or omp <= 0 or ppn <= 0:
+      raise Exception("mpi_procs, omp_threads, and ppn must be larger than 1")
+    if (mpi*omp)%ppn != 0:
+      raise Exception("(mpi_procs * omp_threads) must be a multiple of ppn")
+
+  @staticmethod
+  def parent_script(parameters: dict, job_file: pathlib.Path, work_dir: pathlib.Path) -> str:
+    template = '''\
+#!/bin/bash -x
+#SBATCH --nodes={nodes}
+#SBATCH --ntasks-per-node={ppn}
+#SBATCH --time={walltime}
+. {job_file}
+'''
+    ppn = int(parameters['ppn'])
+    nodes = int(int(parameters['mpi_procs'])*int(parameters['omp_threads'])/ppn)
+    walltime = parameters['walltime']
+    return template.format(nodes=nodes, ppn=ppn, walltime=walltime, job_file=job_file)
+
+  @staticmethod
+  def submit_job(script_path: pathlib.Path, work_dir: pathlib.Path, log_dir: pathlib.Path, log: io.TextIOBase, parameters: dict) -> Tuple[str,str]:
+    cmd = f"sbatch {script_path.absolute()} -D {work_dir.absolute()} -o {log_dir.absolute()} -e {log_dir.absolute()}"
+    log.write(f"cmd: {cmd}\ntime: {datetime.datetime.now()}")
+    result = subprocess.run(cmd, shell=True, check=False, stdout=subprocess.PIPE)
+    output = result.stdout.decode()
+    if result.returncode != 0:
+      log.write(f"rc is not zero: {result.returncode} {output}")
+      raise Exception(f"rc is not zero: {output}")
+    job_id = output.splitlines()[-1]
+    log.write(f"job_id: {job_id}")
+    return (job_id, output)
+
+  @staticmethod
+  def all_status() -> str:
+    cmd = "squeue && sinfo -N"
+    result = subprocess.run(cmd, shell=True, check=False, stdout=subprocess.PIPE)
+    return result.stdout.decode()
+
+  @staticmethod
+  def multiple_status(job_ids: List[str]) -> Dict[str,Tuple[str,str]]:
+    cmd = "squeue"
+    result = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE)
+    output_list = result.stdout.decode().splitlines()
+
+    results = {}
+    for job_id in job_ids:
+      pattern = re.compile(f"^\\s*{job_id}")
+      matched = [line for line in output_list if pattern.match(line)]
+      if matched:
+        results[job_id] = TorqueScheduler._parse_status(matched[-1])
+      else:
+        results[job_id] = ("finished", "not found in squeue")
+    return results
+
+  @staticmethod
+  def _parse_status(line: str) -> Tuple[str,str]:
+    c = line.split()[4]
+    if c == 'PD':
+      return ("queued/pending", line)
+    elif c == 'R' or c == 'T' or c == 'E':
+      return ("running", line)
+    elif c == 'C':
+      return ("finished", line)
+    else:
+      raise Exception(f"unknown format {str}")
+
+  @staticmethod
+  def delete(job_id: str) -> str:
+    cmd = f"scancel {job_id}"
+    result = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE)
+    return result.stdout.decode()

--- a/bin/schedulers/slurm.py
+++ b/bin/schedulers/slurm.py
@@ -49,7 +49,7 @@ class SlurmScheduler:
 
   @staticmethod
   def all_status() -> str:
-    cmd = "squeue && sinfo -N"
+    cmd = "squeue"
     result = subprocess.run(cmd, shell=True, check=False, stdout=subprocess.PIPE)
     return result.stdout.decode()
 
@@ -73,7 +73,7 @@ class SlurmScheduler:
   def _parse_status(line: str) -> Tuple[str,str]:
     c = line.split()[4]
     if c == 'PD':
-      return ("queued/pending", line)
+      return ("queued", line)
     elif c == 'R' or c == 'T' or c == 'E':
       return ("running", line)
     elif c == 'C':

--- a/bin/schedulers/slurm.py
+++ b/bin/schedulers/slurm.py
@@ -64,7 +64,7 @@ class SlurmScheduler:
       pattern = re.compile(f"^\\s*{job_id}")
       matched = [line for line in output_list if pattern.match(line)]
       if matched:
-        results[job_id] = TorqueScheduler._parse_status(matched[-1])
+        results[job_id] = SlurmScheduler._parse_status(matched[-1])
       else:
         results[job_id] = ("finished", "not found in squeue")
     return results

--- a/bin/schedulers/slurm.py
+++ b/bin/schedulers/slurm.py
@@ -36,7 +36,7 @@ class SlurmScheduler:
 
   @staticmethod
   def submit_job(script_path: pathlib.Path, work_dir: pathlib.Path, log_dir: pathlib.Path, log: io.TextIOBase, parameters: dict) -> Tuple[str,str]:
-    cmd = f"sbatch {script_path.absolute()} -D {work_dir.absolute()} -o {log_dir.absolute()} -e {log_dir.absolute()}"
+    cmd = f"sbatch -D {work_dir.absolute()} -o {log_dir.absolute()}/xsub.log -e {log_dir.absolute()}/xsub.log {script_path.absolute()}"
     log.write(f"cmd: {cmd}\ntime: {datetime.datetime.now()}")
     result = subprocess.run(cmd, shell=True, check=False, stdout=subprocess.PIPE)
     output = result.stdout.decode()

--- a/bin/schedulers/slurm.py
+++ b/bin/schedulers/slurm.py
@@ -43,7 +43,7 @@ class SlurmScheduler:
     if result.returncode != 0:
       log.write(f"rc is not zero: {result.returncode} {output}")
       raise Exception(f"rc is not zero: {output}")
-    job_id = output.splitlines()[-1]
+    job_id = output.splitlines()[-1].split(" ")[-1]
     log.write(f"job_id: {job_id}")
     return (job_id, output)
 

--- a/readme.md
+++ b/readme.md
@@ -37,10 +37,12 @@ List of available schedulers.
 - **torque**
   - [Torque](http://www.adaptivecomputing.com/products/open-source/torque/)
   - `qsub`, `qstat`, `qdel` commands are used.
+- **slurm**
+  - [SLURM](https://slurm.schedmd.com/)
+  - `sbatch`, `squeue`, `scancel` commands are used.
 - **fugaku**
   - Fugaku
   - `pjsub`, `pjstat`, `pjdel` commands are used.
-
 
 ## Contact
 


### PR DESCRIPTION
It's been a while since [my last MR](https://github.com/crest-cassia/xsub/pull/32). 

This one introduces support for the SLURM RMS which relies on commands `sbatch`, `squeue`, and `scancel` to submit, check, and cancel jobs.

I tested it on our own cluster, both by directly running `xsub` in interactive mode to submit a job, and through OACIS.
MPI is properly supported, including in cases where multiple processes are assigned to the same host through the `ppn` (process-per-node) option. 
TLDR: It works!